### PR TITLE
Fix small link and list typo

### DIFF
--- a/STATIC/API.md
+++ b/STATIC/API.md
@@ -2,14 +2,14 @@
 
 The Bookworm API acts as an interchange format for requesting data about large collections of texts.
 
-The orthodox implementation at the time of writing is [my BookwormAPI repository](github.com/bmschmidt/BookwormAPI), written in Python and connecting to the MySQL backend.
+The orthodox implementation at the time of writing is [my BookwormAPI repository](https://www.github.com/Bookworm-project/BookwormAPI), written in Python and connecting to the MySQL backend.
 
 One of the major advantages of the API, however, is that it can be implemented on top of other systems (in whole or in part); so that bookcounts queries can easily be run through Solr, for example.
 
 # Setting up an API server
 
 
-[My BookwormAPI repository](github.com/bmschmidt/BookwormAPI) contains the scripts necessary to run an API on a local machine which has a MySQL backend already running.
+[My BookwormAPI repository](https://www.github.com/Bookworm-project/BookwormAPI) contains the scripts necessary to run an API on a local machine which has a MySQL backend already running.
 
 You can clone the repository directly into your webserver's `/cgi-bin` directory, or just download the scripts if there are other cgi-scripts you don't want to disturb. Once it's cloned, you should be able to query the database by hitting, for example, `http://myhost.org/cgi-bin/dbbindings.py?queryTerms={"database":"YOURDBNAME","method":"returnPossibleFields"}`
 

--- a/STATIC/Running.md
+++ b/STATIC/Running.md
@@ -27,8 +27,7 @@ For reference, the general workflow of the Makefile is the following:
 6. Encode unigrams and bigrams from the binaries into `files/encoded`.
 7. Load wordcounts into MySQL database.
 8. Load metadata into MySQL database.
-9.
-10. Create temporary MySQL table and .json file that will be used by the web app.
-11. Create API settings for the web app.
+9. Create temporary MySQL table and .json file that will be used by the web app.
+10. Create API settings for the web app.
 
 At any point, you can backtrack part of the way by clearing out files from `files/targets`.


### PR DESCRIPTION
- "github.com/bmschmidt/BookwormAPI" was interpreted as a relative link, linking to "http://bookworm-project.github.io/Docs/github.com/bmschmidt/BookwormAPI". I added the protocol and changed the pointer to the new repo location.
- as small typo with a missing list item
